### PR TITLE
Updated to latest prebuilt parser version of 2025-04-03

### DIFF
--- a/corelight.conf
+++ b/corelight.conf
@@ -2,7 +2,7 @@
 # Category: NDR
 # Supported Format: JSON
 # Reference: See below
-# Last Updated: 2024-09-20
+# Last Updated: 2025-04-23
 # Copyright 2023 Chronicle LLC
 
 filter {
@@ -4705,29 +4705,6 @@ filter {
       }
       on_error => "var_token_about_not_found"
     }
-    # UDM > Principal
-    mutate {
-      replace => {
-        "principal_hostname_present" => "false"
-      }
-    }
-
-    # Duplicating the ip info into host name to skip the validation while using the udm2sdm flag:
-    # *events_go_proto.Event_Edr: client device for EDR network event must have more than IP addresses filled
-
-    mutate {
-      replace => {
-        "token_principal.hostname" => "%{id.orig_h}"
-      }
-      on_error => "id_orig_h_not_found"
-    }
-    if ![id_orig_h_not_found] {
-      mutate {
-        replace => {
-          "principal_hostname_present" => "true"
-        }
-      }
-    }
 
     # UDM > Target
     mutate {
@@ -4946,8 +4923,8 @@ filter {
     }
 
     # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
-    if [principal_present] == "true" and [target_present] == "true" and
-    [principal_hostname_present] == "true" and [target_file_present] == "true" {
+    if [principal_present] == "true" and [target_present] == "true"
+    and [target_file_present] == "true" {
       if ![action_not_set] {
         if [action] == "SMB::FILE_READ" {
           mutate {
@@ -6246,7 +6223,7 @@ filter {
       if [inference] == "LFD" {
         mutate {
           replace => {
-            "inf_security_result.summary" => "Large Client File Download"
+            "inf_security_result.summary" => "Large Client File Donwload"
           }
         }
         mutate {
@@ -6376,7 +6353,7 @@ filter {
       if [inference] == "RSP" {
         mutate {
           replace => {
-            "inf_security_result.summary" => "Reverse SSH Providioned"
+            "inf_security_result.summary" => "Reverse SSH Provisioned"
           }
         }
         mutate {
@@ -9567,25 +9544,6 @@ filter {
       }
     }
 
-    # Duplicating the ip info into host name to skip the validation while using the udm2sdm flag:
-    # *events_go_proto.Event_Edr: client device for EDR network event must have more than IP addresses filled
-
-    mutate {
-      replace => {
-        "token_principal.hostname" => "%{src}"
-      }
-      on_error => "src_not_found"
-    }
-
-    if [src_not_found] {
-      mutate {
-        replace => {
-          "token_principal.hostname" => "%{id.orig_h}"
-        }
-        on_error => "id_orig_h_not_founc"
-      }
-    }
-
     mutate {
       replace => {
         "orig_vulnerabiliti_details.cve_id" => "%{orig_vulnerable_host.cve}"
@@ -11024,6 +10982,111 @@ filter {
       }
     }
 
+    if ![payload_printable_not_set] and [payload_printable] != "" {
+      mutate {
+        replace => {
+          "copy_payload" => "%{payload_printable}"
+        }
+      }
+    }else if ![payload_decode_failure] {
+      mutate {
+        replace => {
+          "copy_payload" => "%{payload_decoded}"
+        }
+      }
+    }
+
+    if ![payload_printable_not_set] or ![payload_decode_failure]{
+      grok {
+        match => {
+          "copy_payload" =>
+          "%{WORD:http_method} %{NOTSPACE:uri} HTTP/%{NOTSPACE:proto_version}"
+        }
+        overwrite => ["http_method", "uri", "proto_version"]
+        on_error => "uri_not_found"
+      }
+
+      if ![uri_not_found] {
+        mutate {
+          replace => {
+            "token_network.http.method" => "%{http_method}"
+          }
+          on_error => "_"
+        }
+
+        mutate {
+          replace => {
+            "token_network.application_protocol_version" => "%{proto_version}"
+          }
+          on_error => "_"
+        }
+
+        mutate {
+          replace => {
+            "token_target.url" => "%{uri}"
+          }
+          on_error => "_"
+        }
+      }
+
+      mutate {
+        gsub => ["copy_payload", "\\r\\n", "##"]
+      }
+
+      mutate {
+        split => {
+          source => "copy_payload"
+          separator => "##"
+          target => "lines"
+        }
+      }
+
+      mutate {
+        replace => {
+          "user_agent" => ""
+          "hostname" => ""
+        }
+      }
+
+      for line in lines {
+        grok {
+          match => {
+            "line" =>
+            "^User-Agent: %{GREEDYDATA:user_agent}"
+          }
+          overwrite => ["user_agent"]
+          on_error => "_"
+        }
+
+        grok {
+          match => {
+            "line" =>
+            "^Host: %{IPORHOST:hostname}"
+          }
+          overwrite => ["hostname"]
+          on_error => "_"
+        }
+
+      }
+
+      if [user_agent] != "" {
+        mutate {
+          replace => {
+            "token_network.http.user_agent" => "%{user_agent}"
+          }
+        }
+      }
+
+      if [hostname] != "" {
+        mutate {
+          replace => {
+            "token_target.hostname" => "%{hostname}"
+          }
+        }
+      }
+    }
+
+
     for reference in references {
       mutate {
         convert => {
@@ -11287,16 +11350,6 @@ filter {
         "%{orig_vulnerable_host.os_version}"
       }
       on_error => "orig_vulnerable_host_os_version_not_found"
-    }
-
-    # Duplicating the ip info into host name to skip the validation while using the udm2sdm flag:
-    # *events_go_proto.Event_Edr: client device for EDR network event must have more than IP addresses filled
-
-    mutate {
-      replace => {
-        "token_principal.hostname" => "%{id.orig_h}"
-      }
-      on_error => "id_orig_h_not_found"
     }
 
     # UDM > Target
@@ -13703,15 +13756,6 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # Duplicating the ip info into host name to skip the validation while using the udm2sdm flag:
-    # *events_go_proto.Event_Edr: client device for EDR network event must have more than IP addresses filled
-    mutate {
-      replace => {
-        "token_principal.hostname" => "%{id.orig_h}"
-      }
-      on_error => "id_orig_h_not_found"
-    }
-
     # Check if required udm validation fields for SCAN_NETWORK exist.
     if [principal_present] == "true" {
       mutate {
@@ -13839,17 +13883,6 @@ filter {
         replace => {
           "principal_present" => "true"
         }
-      }
-    }
-    else {
-      # Duplicating the ip info into host name to skip the validation while using the udm2sdm flag:
-      # *events_go_proto.Event_Edr: client device for EDR network event must have more than IP addresses filled
-
-      mutate {
-        replace => {
-          "token_principal.hostname" => "%{id.orig_h}"
-        }
-        on_error => "id_orig_h_not_found"
       }
     }
 
@@ -17740,14 +17773,6 @@ filter {
 
     # Check if required udm validation fields for STATUS_UPDATE exist.
     if [principal_present] == "true" {
-      # Duplicating the ip info into host name to skip the validation while using the udm2sdm flag:
-      # *events_go_proto.Event_Edr: client device for EDR network event must have more than IP addresses filled
-      mutate {
-        replace => {
-          "token_principal.hostname" => "%{id.orig_h}"
-        }
-        on_error => "id_orig_h_not_found"
-      }
       mutate {
         replace => {
           "token_metadata.event_type" => "STATUS_UPDATE"
@@ -19751,16 +19776,6 @@ filter {
             "token_metadata.event_type" => "GENERIC_EVENT"
           }
         }
-      }
-    }
-    # Duplicating the ip info into host name to skip the validation while using the udm2sdm flag:
-    # *events_go_proto.Event_Edr: client device for EDR network event must have more than IP addresses filled
-    if [principal_present] == "true" {
-      mutate {
-        replace => {
-          "token_principal.hostname" => "%{src_ip}"
-        }
-        on_error => "src_ip_not_found"
       }
     }
   }
@@ -39573,7 +39588,142 @@ filter {
   }
   else {
 
-    @include["noun_host_asset_align.include"]
+    mutate{
+  replace=>{
+    "principal_hostname"=>"%{event.idm.read_only_udm.principal.hostname}"
+  }
+  on_error=>"no_principal_hostname"
+}
+
+mutate {
+  replace => {
+    "principal_asset_hostname" =>
+    "%{event.idm.read_only_udm.principal.asset.hostname}"
+  }
+  on_error => "not_prsent_pricipal_asset_host"
+}
+
+if [not_prsent_pricipal_asset_host] and ![no_principal_hostname] and
+[principal_hostname] != "" {
+  mutate {
+    replace => {
+      "event.idm.read_only_udm.principal.asset.hostname" =>
+      "%{principal_hostname}"
+    }
+  }
+}
+
+else if ![not_prsent_pricipal_asset_host] and [no_principal_hostname] and
+[principal_asset_hostname] != "" {
+  mutate {
+    replace => {
+      "event.idm.read_only_udm.principal.hostname" =>
+      "%{principal_asset_hostname}"
+    }
+  }
+}
+else if ![not_prsent_pricipal_asset_host] and ![no_principal_hostname] and
+([principal_hostname] != [principal_asset_hostname]) {
+  mutate {
+    replace => {
+      "event.idm.read_only_udm.principal.asset.hostname" =>
+      "%{principal_hostname}"
+    }
+  }
+  mutate {
+    replace => {
+      "token_new" => ""
+    }
+  }
+  mutate {
+    replace => {
+      "token_new.value" => "%{principal_asset_hostname}"
+    }
+    on_error => "no_filed_present"
+  }
+  if ![no_filed_present] and [token_new][value] != "" {
+    mutate {
+      replace => {
+        "token_new.key" => "asset_host_name"
+      }
+    }
+    mutate {
+      merge => {
+        "event.idm.read_only_udm.principal.asset.attribute.labels" =>
+        "token_new"
+      }
+    }
+  }
+}
+
+mutate{
+  replace=>{
+    "target_hostname"=>"%{event.idm.read_only_udm.target.hostname}"
+  }
+  on_error=>"no_target_hostname"
+}
+
+mutate {
+  replace => {
+    "target_asset_hostname" =>
+    "%{event.idm.read_only_udm.target.asset.hostname}"
+  }
+  on_error => "not_prsent_target_asset_host"
+}
+
+if [not_prsent_target_asset_host] and ![no_target_hostname] and
+[target_hostname] != "" {
+  mutate {
+    replace => {
+      "event.idm.read_only_udm.target.asset.hostname" =>
+      "%{target_hostname}"
+    }
+  }
+}
+
+else if ![not_prsent_target_asset_host] and [no_target_hostname] and
+[target_asset_hostname] != "" {
+  mutate {
+    replace => {
+      "event.idm.read_only_udm.target.hostname" =>
+      "%{target_asset_hostname}"
+    }
+  }
+}
+else if ![not_prsent_target_asset_host] and ![no_target_hostname] and
+([target_hostname] != [target_asset_hostname]) {
+  mutate {
+    replace => {
+      "event.idm.read_only_udm.target.asset.hostname" =>
+      "%{target_hostname}"
+    }
+  }
+  mutate {
+    replace => {
+      "token_new" => ""
+    }
+  }
+  mutate {
+    replace => {
+      "token_new.value" => "%{target_asset_hostname}"
+    }
+    on_error => "no_filed_present"
+  }
+  if ![no_filed_present] and [token_new][value] != "" {
+    mutate {
+      replace => {
+        "token_new.key" => "device_host_name"
+      }
+    }
+    mutate {
+      merge => {
+        "event.idm.read_only_udm.target.asset.attribute.labels" =>
+        "token_new"
+      }
+    }
+  }
+}
+
 
     mutate {
       merge => {


### PR DESCRIPTION
Current version was 2024-09-20 and 2 changelogs behind.
Added 2025-04-08: Updated principal.hostname mapped as per the new event_type validation.
Added 2025-04-23: Modified the static value of "security_result.summary" UDM field from "Providioned" to "Provisioned" for the event "ssh".